### PR TITLE
Fix ctrl + arrow navigation in readline

### DIFF
--- a/bash/input.sh
+++ b/bash/input.sh
@@ -10,8 +10,10 @@ set mark-symlinked-directories on
 # More intelligent Up/Down behavior.
 "\e[B": history-search-forward
 "\e[A": history-search-backward
-"\e[C": forward-char
-"\e[D": backward-char
+
+# History search seems to breaks these, this will reset them to work normally.
+"\e[1;5C": forward-word
+"\e[1;5D": backward-word
 
 # Do not autocomplete hidden files unless the pattern begins with a dot.
 set match-hidden-files off


### PR DESCRIPTION
Word skipping using the arrow keys were broken after adding history search on up/down. This fixes that.